### PR TITLE
GOK-134 | Introduce new global property for rest base URL

### DIFF
--- a/omod/src/main/java/org/openmrs/module/openhmis/backboneforms/web/controller/InitJsController.java
+++ b/omod/src/main/java/org/openmrs/module/openhmis/backboneforms/web/controller/InitJsController.java
@@ -43,6 +43,19 @@ public class InitJsController {
 
 		model.addAttribute("maxResults", maxResults);
 		model.addAttribute("contextPath", request.getContextPath());
-		model.addAttribute("restUrl", RestConstants.URI_PREFIX);
+		model.addAttribute("restUrl", getRestUrl());
+	}
+
+	private String getRestUrl() {
+		String openHmisBaseURL = Context.getAdministrationService().getGlobalProperty("openhmis.rest.baseurl");
+		if(openHmisBaseURL == null)
+			return null;
+
+		if (!openHmisBaseURL.endsWith("/")) {
+			openHmisBaseURL = openHmisBaseURL + "/";
+		}
+		openHmisBaseURL = openHmisBaseURL + "ws/rest/";
+
+		return openHmisBaseURL;
 	}
 }

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -19,14 +19,19 @@
 		<require_module>org.openmrs.module.webservices.rest</require_module>
 		<require_module>org.openmrs.module.openhmis.commons</require_module>
 	</require_modules>
-	
+
 	<!-- Module Activator -->
 	<activator>${project.parent.groupId}.${project.parent.artifactId}.BackboneFormsActivator</activator>
-	
-	
+
+	<globalProperty>
+		<property>openhmis.rest.baseurl</property>
+		<description>The URI prefix through which inventory frontend will use to build rest URLS, should be of the form http://{ipAddress}:{port}/{contextPath}. Example https://localhost/openmrs
+		</description>
+	</globalProperty>
+
 	<!-- Maps hibernate file's, if present -->
 	<mappingFiles>
-				
+
 	</mappingFiles>
 
 	<!-- Internationalization -->


### PR DESCRIPTION
This PR removes the dependency of inventory OMOD on Rest Web Services URL prefix and now depends on the `openhmis.rest.baseurl` property